### PR TITLE
Add support for EdDSA (specifically Ed25519, though Ed448 should work…

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,66 +1,58 @@
 {
-	"name" : "jwtd",
-	"description" : "D implementation of JSON Web Token.",
-	"license": "MIT",
-	"authors": [
-		"Oleh Havrys",
-		"Sergey Buth",
-		"Tomáš Chaloupka",
-		"Lionello Lunesu"
-	],
-	"configurations": [
-		{
-			"name": "openssl",
-			"targetType": "library",
-			"dependencies" : {
-				"openssl": "~>1.1.4+1.0.1g"
-			},
-			"versions": ["UseOpenSSL"]
-		},
-		{
-			"name": "openssl-1.1",
-			"targetType": "library",
-			"dependencies" : {
-				"openssl": "~>1.1.4+1.0.1g"
-			},
-			"versions": ["UseOpenSSL", "OpenSSL11"]
-		},
-		{
-			"name": "botan",
-			"targetType": "library",
-			"dependencies" : {
-				"botan": "~>1.12.0"
-			},
-			"versions": ["UseBotan"]
-		},
-		{
-			"name": "phobos",
-			"targetType": "library",
-			"versions": ["UsePhobos"]
-		},
-		{
-			"name": "unittest-openssl",
-			"mainSourceFile": "source/app.d",
-			"targetType": "executable",
-			"dependencies" : {
-				"openssl": "~>1.1.4+1.0.1g"
-			},
-			"versions": ["UseOpenSSL"]
-		},
-		{
-			"name": "unittest-botan",
-			"mainSourceFile": "source/app.d",
-			"targetType": "executable",
-			"dependencies" : {
-				"botan": "~>1.12.0"
-			},
-			"versions": ["UseBotan"]
-		},
-		{
-			"name": "unittest-phobos",
-			"mainSourceFile": "source/app.d",
-			"targetType": "executable",
-			"versions": ["UsePhobos"]
-		}
-	]
+  "name": "jwtd",
+  "description": "D implementation of JSON Web Token.",
+  "license": "MIT",
+  "authors": [
+    "Oleh Havrys",
+    "Sergey Buth",
+    "Tomáš Chaloupka",
+    "Lionello Lunesu"
+  ],
+  "configurations": [
+    {
+      "name": "openssl-3.4",
+      "targetType": "library",
+      "dependencies": {
+        "openssl": "~>3.4.0"
+      },
+      "versions": ["UseOpenSSL"]
+    },
+    {
+      "name": "botan",
+      "targetType": "library",
+      "dependencies": {
+        "botan": "~>1.12.0"
+      },
+      "versions": ["UseBotan"]
+    },
+    {
+      "name": "phobos",
+      "targetType": "library",
+      "versions": ["UsePhobos"]
+    },
+    {
+      "name": "unittest-openssl",
+      "mainSourceFile": "source/app.d",
+      "targetType": "executable",
+      "dependencies": {
+        "openssl": "~>3.4.0"
+      },
+      "versions": ["UseOpenSSL"]
+    },
+    {
+      "name": "unittest-botan",
+      "mainSourceFile": "source/app.d",
+      "targetType": "executable",
+      "dependencies": {
+        "botan": "~>1.12.0"
+      },
+      "versions": ["UseBotan"]
+    },
+    {
+      "name": "unittest-phobos",
+      "mainSourceFile": "source/app.d",
+      "targetType": "executable",
+      "versions": ["UsePhobos"]
+    }
+  ]
 }

--- a/source/jwtd/jwt.d
+++ b/source/jwtd/jwt.d
@@ -27,7 +27,8 @@ enum JWTAlgorithm : string {
 	RS512 = "RS512",
 	ES256 = "ES256",
 	ES384 = "ES384",
-	ES512 = "ES512"
+	ES512 = "ES512",
+	EdDSA = "EdDSA"
 }
 
 class SignException : Exception {
@@ -118,8 +119,13 @@ JSONValue decode(string token, string delegate(ref JSONValue jose) lazyKey) {
 
 	JWTAlgorithm alg;
 	try {
+	    auto algName = toUpper(header["alg"].str);
 		// toUpper for none
-		alg = to!(JWTAlgorithm)(toUpper(header["alg"].str()));
+		if (algName == "EDDSA") {
+		    alg = JWTAlgorithm.EdDSA;
+		} else {
+		    alg = to!(JWTAlgorithm)(algName);
+		}
 	} catch(Exception e) {
 		throw new VerifyException("Algorithm is incorrect.");
 	}
@@ -176,6 +182,7 @@ unittest {
             JWTAlgorithm.ES256 : Keys(es256_private, es256_public),
             JWTAlgorithm.ES384 : Keys(es384_private, es384_public),
             JWTAlgorithm.ES512 : Keys(es512_private, es512_public),
+            JWTAlgorithm.EdDSA : Keys(ed25519_private, ed25519_public),
         ];
     }
 

--- a/source/jwtd/jwt_openssl.d
+++ b/source/jwtd/jwt_openssl.d
@@ -150,6 +150,36 @@ version(UseOpenSSL) {
 		return eckey;
 	}
 
+	EVP_PKEY *getEdPublicKey(string key) {
+	    EVP_PKEY* pkey;
+
+		BIO* bpo = BIO_new_mem_buf(cast(char*)key.ptr, -1);
+		if(bpo is null) {
+		    throw new Exception("Can't load the key.");
+		}
+		scope(exit) BIO_free(bpo);
+        pkey = PEM_read_bio_PUBKEY(bpo, null, null, null);
+        if (pkey is null) {
+            throw new Exception("Can't load public key from PEM.");
+        }
+        return pkey;
+	}
+
+	EVP_PKEY *getEdPrivateKey(string key) {
+	    EVP_PKEY* pkey;
+
+		BIO* bpo = BIO_new_mem_buf(cast(char*)key.ptr, -1);
+		if(bpo is null) {
+		    throw new Exception("Can't load the key.");
+		}
+		scope(exit) BIO_free(bpo);
+		pkey = PEM_read_bio_PrivateKey(bpo, null, null, null);
+		if (pkey is null) {
+		    throw new Exception("Can't load private key from PEM.");
+		}
+        return pkey;
+	}
+
     unittest {
         import jwtd.test;
         import std.exception : assertThrown;
@@ -167,31 +197,9 @@ version(UseOpenSSL) {
 		void sign_hs(const(EVP_MD)* evp, uint signLen) {
 			sign = new ubyte[signLen];
 
-			version(OpenSSL30) {
-				auto ret = HMAC(evp, key.ptr, cast(int)key.length, cast(const(ubyte)*)msg.ptr, cast(ulong)msg.length, cast(ubyte*)sign.ptr, &signLen);
-				if (ret is null) {
-					throw new Exception("Can't initialize HMAC context.");
-				}
-			} else {
-				HMAC_CTX ctx;
-
-				version(OpenSSL11) {
-					scope(exit) HMAC_CTX_reset(&ctx);
-					HMAC_CTX_reset(&ctx);
-				}
-				else {
-					scope(exit) HMAC_CTX_cleanup(&ctx);
-					HMAC_CTX_init(&ctx);
-				}
-				if(0 == HMAC_Init_ex(&ctx, key.ptr, cast(int)key.length, evp, null)) {
-					throw new Exception("Can't initialize HMAC context.");
-				}
-				if(0 == HMAC_Update(&ctx, cast(const(ubyte)*)msg.ptr, cast(ulong)msg.length)) {
-					throw new Exception("Can't update HMAC.");
-				}
-				if(0 == HMAC_Final(&ctx, cast(ubyte*)sign.ptr, &signLen)) {
-					throw new Exception("Can't finalize HMAC.");
-				}
+			auto ret = HMAC(evp, key.ptr, cast(int)key.length, cast(const(ubyte)*)msg.ptr, cast(ulong)msg.length, cast(ubyte*)sign.ptr, &signLen);
+			if (ret is null) {
+				throw new Exception("Can't initialize HMAC context.");
 			}
 		}
 
@@ -230,6 +238,38 @@ version(UseOpenSSL) {
 			if(!i2d_ECDSA_SIG(sig, &c)) {
 				throw new Exception("Convert sign to DER format failed.");
 			}
+		}
+
+		/// Sign using Edwards curve, which includes an intrinsic hash as part of the key.
+		/// Ed25519 uses SHA512 (64 byte hash), and Ed448 uses SHAKE256 (114 byte hash).
+		/// Thus we simply encode the hashing inside this function.
+		void sign_ed() {
+		    EVP_PKEY *pkey = getEdPrivateKey(key);
+			scope(exit) EVP_PKEY_free(pkey);
+
+			// EdDSA implies hash as part of the algo
+			auto md_ctx = EVP_MD_CTX_new();
+			if (md_ctx is null) {
+			    throw new Exception("Can't get MD context.");
+			}
+			scope(exit) EVP_MD_CTX_free(md_ctx);
+
+            if (EVP_DigestSignInit(md_ctx, null, null, null, pkey) == 0) {
+                throw new Exception("Can't initialize digest.");
+            }
+
+            // Get the signature length - we can do this for an empty message as the hash length
+            // is not dependent on the message length.
+            ulong sigLen = 0;
+            if (EVP_DigestSign(md_ctx, null, &sigLen, null, 0) == 0) {
+                throw new Exception("Can't determine digest length.");
+            }
+
+            // Now do the signature for real with the right length.
+            sign = new ubyte[sigLen];
+            if (EVP_DigestSign(md_ctx, cast(ubyte *)sign.ptr, &sigLen, cast(const (ubyte)*)msg.ptr, msg.length) == 0) {
+                throw new Exception("Can't sign message.");
+            }
 		}
 
 		switch(algo) {
@@ -284,6 +324,10 @@ version(UseOpenSSL) {
 				sign_es(NID_secp521r1, hash.ptr, SHA512_DIGEST_LENGTH);
 				break;
 			}
+			case JWTAlgorithm.EdDSA: {
+			    sign_ed();
+				break;
+			}
 
 			default:
 				throw new SignException("Wrong algorithm.");
@@ -330,6 +374,28 @@ version(UseOpenSSL) {
 			return ret == 1;
 		}
 
+		bool verify_ed() {
+		    EVP_PKEY* pkey = getEdPublicKey(key);
+			scope(exit) EVP_PKEY_free(pkey);
+
+			// EdDSA implies hash as part of the algo
+			auto md_ctx = EVP_MD_CTX_new();
+			if (md_ctx is null) {
+			    throw new Exception("Can't get MD context.");
+			}
+			scope(exit) EVP_MD_CTX_free(md_ctx);
+            if (EVP_DigestVerifyInit(md_ctx, null, null, null, pkey) == 0) {
+                throw new Exception("Can't initialize digest.");
+            }
+
+         	ubyte* sig = cast(ubyte*)signature.ptr;
+            ubyte* m = cast(ubyte*)signing_input.ptr;
+            long sigLen = signature.length;
+            long mLen = signing_input.length;
+
+            return EVP_DigestVerify(md_ctx, sig, sigLen, m, mLen) == 1;
+		}
+
 		switch(algo) {
 			case JWTAlgorithm.NONE: {
 				return key.length == 0;
@@ -369,6 +435,9 @@ version(UseOpenSSL) {
 				ubyte[] hash = new ubyte[SHA512_DIGEST_LENGTH];
 				SHA512(cast(const(ubyte)*)signing_input.ptr, signing_input.length, hash.ptr);
 				return verify_es(NID_secp521r1, hash.ptr, SHA512_DIGEST_LENGTH );
+			}
+			case JWTAlgorithm.EdDSA: {
+			    return verify_ed();
 			}
 
 			default:

--- a/source/jwtd/jwt_phobos.d
+++ b/source/jwtd/jwt_phobos.d
@@ -39,6 +39,7 @@ version (UsePhobos) {
 			case JWTAlgorithm.ES256:
 			case JWTAlgorithm.ES384:
 			case JWTAlgorithm.ES512:
+			case JWTAlgorithm.EdDSA:
 				throw new SignException("Unsupported algorithm.");
 			default:
 				throw new SignException("Wrong algorithm.");
@@ -61,6 +62,7 @@ version (UsePhobos) {
 			case JWTAlgorithm.ES256:
 			case JWTAlgorithm.ES384:
 			case JWTAlgorithm.ES512:
+			case JWTAlgorithm.EdDSA:
 				throw new SignException("Unsupported algorithm.");
 			default:
 				throw new VerifyException("Wrong algorithm.");
@@ -85,4 +87,3 @@ version (UsePhobos) {
         }
     }
 }
-

--- a/source/jwtd/test.d
+++ b/source/jwtd/test.d
@@ -150,4 +150,16 @@ yQcf/J8EltCqbKYT0dH5qJFlc6WKQIRNms9DNRhZmAPCbFVgcLCvXMg6X9rmHM6q
 -----END PUBLIC KEY-----
 EOS";
 
+    string ed25519_private = q"EOS
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJND1JPxhYzbvlwUM2vkcjXpuBh0/qKjdkHbEy88eOjd
+-----END PRIVATE KEY-----
+EOS";
+
+    string ed25519_public = q"EOS
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEApzmKzPHspeKgp5gJiAkYZXMegomna4DWsPV9Pg6VRyc=
+-----END PUBLIC KEY-----
+EOS";
+
 } // version (unittest)


### PR DESCRIPTION
… as well).

This is only supported for now using openssl, and we have bumped the OpenSSL support to version 3.4.  (The D wrapper library is not yet updated with 3.5 support).

Botan support can be added later, as Botan apparently can do these algorithms, but we aren't using Botan at Weka right now.

I intend to add EdDSA to WEKA so we can use it for mount tokens and other JWTs.  (For mount tokens it will let us shrink the mount token which is needed for some versions of Linux.)