### PR TITLE
Add RFC 9864 algorithm identifiers.

### DIFF
--- a/source/jwtd/jwt.d
+++ b/source/jwtd/jwt.d
@@ -18,17 +18,22 @@ version(UsePhobos) {
 }
 
 enum JWTAlgorithm : string {
-	NONE  = "none",
-	HS256 = "HS256",
-	HS384 = "HS384",
-	HS512 = "HS512",
-	RS256 = "RS256",
-	RS384 = "RS384",
-	RS512 = "RS512",
-	ES256 = "ES256",
-	ES384 = "ES384",
-	ES512 = "ES512",
-	EdDSA = "EdDSA"
+	NONE    = "none",
+	HS256   = "HS256",
+	HS384   = "HS384",
+	HS512   = "HS512",
+	RS256   = "RS256",
+	RS384   = "RS384",
+	RS512   = "RS512",
+	Ed25519 = "Ed25519",
+	Ed448   = "Ed448",
+	ESP256  = "ESP256",
+	ESP384  = "ESP384",
+	ESP512  = "ESP512",
+	EdDSA   = "EdDSA", // Deprecated
+	ES256   = "ES256", // Deprecated
+	ES384   = "ES384", // Deprecated
+	ES512   = "ES512", // Deprecated
 }
 
 class SignException : Exception {
@@ -123,6 +128,10 @@ JSONValue decode(string token, string delegate(ref JSONValue jose) lazyKey) {
 		// toUpper for none
 		if (algName == "EDDSA") {
 		    alg = JWTAlgorithm.EdDSA;
+		} else if (algName == "ED25519") {
+		    alg = JWTAlgorithm.Ed25519;
+		} else if (algName == "ED448") {
+            alg = JWTAlgorithm.Ed448;
 		} else {
 		    alg = to!(JWTAlgorithm)(algName);
 		}
@@ -183,6 +192,11 @@ unittest {
             JWTAlgorithm.ES384 : Keys(es384_private, es384_public),
             JWTAlgorithm.ES512 : Keys(es512_private, es512_public),
             JWTAlgorithm.EdDSA : Keys(ed25519_private, ed25519_public),
+            JWTAlgorithm.ESP256 : Keys(es256_private, es256_public),
+            JWTAlgorithm.ESP384 : Keys(es384_private, es384_public),
+            JWTAlgorithm.ESP512 : Keys(es512_private, es512_public),
+            JWTAlgorithm.Ed25519 : Keys(ed25519_private, ed25519_public),
+            JWTAlgorithm.Ed448 : Keys(ed448_private, ed448_public),
         ];
     }
 
@@ -193,8 +207,12 @@ unittest {
             // JWTAlgorithm.RS384 : Keys(private384, public384),
             // JWTAlgorithm.RS512 : Keys(private512, public512),
             // JWTAlgorithm.ES256 : Keys(es256_private, es256_public),
+            // JWTAlgorithm.ESP256 : Keys(es256_private, es256_public),
             // JWTAlgorithm.ES384 : Keys(es384_private, es384_public),
+            // JWTAlgorithm.ESP384 : Keys(es384_private, es384_public),
             // JWTAlgorithm.ES512 : Keys(es512_private, es512_public),
+            // JWTAlgorithm.ESP512 : Keys(es512_private, es512_public),
+            // JWTAlgorithm.EdDSA : Keys(ed25519_private, ed25519_public),
         ];
     }
 

--- a/source/jwtd/jwt_botan.d
+++ b/source/jwtd/jwt_botan.d
@@ -70,13 +70,13 @@ version (UseBotan) {
 			case JWTAlgorithm.RS512:
 				sign_rs("EMSA3(SHA-512)");
 				break;
-			case JWTAlgorithm.ES256:
+			case JWTAlgorithm.ES256, JWTAlgorithm.ESP256:
 				sign_es("EMSA1(SHA-256)");
 				break;
-			case JWTAlgorithm.ES384:
+			case JWTAlgorithm.ES384, JWTAlgorithm.ESP384:
 				sign_es("EMSA1(SHA-384)");
 				break;
-			case JWTAlgorithm.ES512:
+			case JWTAlgorithm.ES512, JWTAlgorithm.ESP512:
 				sign_es("EMSA1(SHA-512)");
 				break;
 			default:
@@ -125,11 +125,11 @@ version (UseBotan) {
 				return verify_rs("EMSA3(SHA-384)");
 			case JWTAlgorithm.RS512:
 				return verify_rs("EMSA3(SHA-512)");
-			case JWTAlgorithm.ES256:
+			case JWTAlgorithm.ES256, JWTAlgorithm.ESP256:
 				return verify_es("EMSA1(SHA-256)");
-			case JWTAlgorithm.ES384:
+			case JWTAlgorithm.ES384, JWTAlgorithm.ESP384:
 				return verify_es("EMSA1(SHA-384)");
-			case JWTAlgorithm.ES512:
+			case JWTAlgorithm.ES512, JWTAlgorithm.ESP512:
 				return verify_es("EMSA1(SHA-512)");
 			default:
 				throw new VerifyException("Wrong algorithm.");

--- a/source/jwtd/jwt_openssl.d
+++ b/source/jwtd/jwt_openssl.d
@@ -306,25 +306,25 @@ version(UseOpenSSL) {
 				sign_rs(hash.ptr, NID_sha512, 512, SHA512_DIGEST_LENGTH);
 				break;
 			}
-			case JWTAlgorithm.ES256: {
+			case JWTAlgorithm.ESP256, JWTAlgorithm.ES256: {
 				ubyte[] hash = new ubyte[SHA256_DIGEST_LENGTH];
 				SHA256(cast(const(ubyte)*)msg.ptr, msg.length, hash.ptr);
 				sign_es(NID_X9_62_prime256v1, hash.ptr, SHA256_DIGEST_LENGTH);
 				break;
 			}
-			case JWTAlgorithm.ES384: {
+			case JWTAlgorithm.ESP384, JWTAlgorithm.ES384: {
 				ubyte[] hash = new ubyte[SHA384_DIGEST_LENGTH];
 				SHA384(cast(const(ubyte)*)msg.ptr, msg.length, hash.ptr);
 				sign_es(NID_secp384r1, hash.ptr, SHA384_DIGEST_LENGTH);
 				break;
 			}
-			case JWTAlgorithm.ES512: {
+			case JWTAlgorithm.ESP512, JWTAlgorithm.ES512: {
 				ubyte[] hash = new ubyte[SHA512_DIGEST_LENGTH];
 				SHA512(cast(const(ubyte)*)msg.ptr, msg.length, hash.ptr);
 				sign_es(NID_secp521r1, hash.ptr, SHA512_DIGEST_LENGTH);
 				break;
 			}
-			case JWTAlgorithm.EdDSA: {
+			case JWTAlgorithm.EdDSA, JWTAlgorithm.Ed25519, JWTAlgorithm.Ed448: {
 			    sign_ed();
 				break;
 			}
@@ -421,22 +421,22 @@ version(UseOpenSSL) {
 				return verify_rs(hash.ptr, NID_sha512, 512, SHA512_DIGEST_LENGTH);
 			}
 
-			case JWTAlgorithm.ES256:{
+			case JWTAlgorithm.ESP256, JWTAlgorithm.ES256:{
 				ubyte[] hash = new ubyte[SHA256_DIGEST_LENGTH];
 				SHA256(cast(const(ubyte)*)signing_input.ptr, signing_input.length, hash.ptr);
 				return verify_es(NID_X9_62_prime256v1, hash.ptr, SHA256_DIGEST_LENGTH );
 			}
-			case JWTAlgorithm.ES384:{
+			case JWTAlgorithm.ESP384, JWTAlgorithm.ES384:{
 				ubyte[] hash = new ubyte[SHA384_DIGEST_LENGTH];
 				SHA384(cast(const(ubyte)*)signing_input.ptr, signing_input.length, hash.ptr);
 				return verify_es(NID_secp384r1, hash.ptr, SHA384_DIGEST_LENGTH );
 			}
-			case JWTAlgorithm.ES512: {
+			case JWTAlgorithm.ESP512, JWTAlgorithm.ES512: {
 				ubyte[] hash = new ubyte[SHA512_DIGEST_LENGTH];
 				SHA512(cast(const(ubyte)*)signing_input.ptr, signing_input.length, hash.ptr);
 				return verify_es(NID_secp521r1, hash.ptr, SHA512_DIGEST_LENGTH );
 			}
-			case JWTAlgorithm.EdDSA: {
+			case JWTAlgorithm.EdDSA, JWTAlgorithm.Ed25519, JWTAlgorithm.Ed448: {
 			    return verify_ed();
 			}
 

--- a/source/jwtd/jwt_phobos.d
+++ b/source/jwtd/jwt_phobos.d
@@ -39,7 +39,12 @@ version (UsePhobos) {
 			case JWTAlgorithm.ES256:
 			case JWTAlgorithm.ES384:
 			case JWTAlgorithm.ES512:
+			case JWTAlgorithm.ESP256:
+			case JWTAlgorithm.ESP384:
+			case JWTAlgorithm.ESP512:
 			case JWTAlgorithm.EdDSA:
+			case JWTAlgorithm.Ed25519:
+			case JWTAlgorithm.Ed448:
 				throw new SignException("Unsupported algorithm.");
 			default:
 				throw new SignException("Wrong algorithm.");
@@ -63,6 +68,11 @@ version (UsePhobos) {
 			case JWTAlgorithm.ES384:
 			case JWTAlgorithm.ES512:
 			case JWTAlgorithm.EdDSA:
+			case JWTAlgorithm.ESP256:
+			case JWTAlgorithm.ESP384:
+			case JWTAlgorithm.ESP512:
+			case JWTAlgorithm.Ed25519:
+			case JWTAlgorithm.Ed448:
 				throw new SignException("Unsupported algorithm.");
 			default:
 				throw new VerifyException("Wrong algorithm.");

--- a/source/jwtd/test.d
+++ b/source/jwtd/test.d
@@ -162,4 +162,18 @@ MCowBQYDK2VwAyEApzmKzPHspeKgp5gJiAkYZXMegomna4DWsPV9Pg6VRyc=
 -----END PUBLIC KEY-----
 EOS";
 
+    string ed448_private = q"EOS
+-----BEGIN PRIVATE KEY-----
+MEcCAQAwBQYDK2VxBDsEOYaX+nGO8coh9GZ7qgauzOOaogvUeXlSyaPyT13eVUE8
+i1l9OMyHUs25rGAKsxZvK45a/I8VQ+84qg==
+-----END PRIVATE KEY-----
+EOS";
+
+    string ed448_public = q"EOS
+-----BEGIN PUBLIC KEY-----
+MEMwBQYDK2VxAzoASQ/pN8uTJ5KhAYxT/EjhqYl1XGXQRuQii09cPo60QFWX68xv
+Iaqa3tN7bYhbqBkxGwHtx6iSUAIA
+-----END PUBLIC KEY-----
+EOS";
+
 } // version (unittest)


### PR DESCRIPTION
The old EdDSA and ESxxx algoirthms are technically parameterized (although we weren't doing the right thing there).  RFC 9864 provides new identifiers that are "fully" specified.